### PR TITLE
Get CascaDict working with Py 3's import system

### DIFF
--- a/cascadict/__init__.py
+++ b/cascadict/__init__.py
@@ -1,1 +1,1 @@
-from cascadict import CascaDict, CascaDictError
+from .cascadict import CascaDict, CascaDictError


### PR DESCRIPTION
When importing in python3, I get the following message:
.../.tox/py34/lib/python3.4/site-packages/cascadict/**init**.py", line 1, in <module>
    from cascadict import CascaDict, CascaDictError
ImportError: cannot import name 'CascaDict'

If we make **init**.py use a relative import, it works in both python 2 and 3.
